### PR TITLE
Simplest prod(xs; dims) gradient

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Tracker"
 uuid = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
-version = "0.2.8"
+version = "0.2.9"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -358,15 +358,13 @@ Base.sum(f::Union{Function,Type},xs::TrackedArray) = sum(f.(xs))
 @grad sum(xs; dims = :) = sum(data(xs), dims = dims),
   Δ -> (zero(xs) .+ Δ, )
 
-Base.prod(xs::TrackedArray, dim) = track(prod, xs, dim)
-Base.prod(xs::TrackedArray) = track(prod, xs)
+Base.prod(xs::TrackedArray; dims=:) = track(prod, xs; dims=dims)
 Base.prod(f::Union{Function, Type}, xs::TrackedArray) = prod(f.(xs))
 
-@grad prod(xs) = prod(data(xs)), Δ -> (prod(xs) ./ xs .* Δ,)
-@grad prod(xs, dim) = prod(data(xs), dims = dim),
-  Δ -> (nobacksies(:sum,
-          reshape(.*(circshift.([reshape(data(xs), length(xs))], 1:length(xs)-1)...), size(xs)) .* Δ),
-        nothing)
+@grad function prod(xs; dims=:)
+  p = prod(data(xs); dims=dims)
+  p, Δ -> (p ./ xs .* Δ,)
+end
 
 Base.findfirst(xs::TrackedArray, args...) = findfirst(xs.data, args...)
 


### PR DESCRIPTION
As promised in https://github.com/FluxML/Flux.jl/pull/524, this makes the gradient for `prod` understand keyword `dims` (rather than falling back to TrackedReal). It does not treat zeros correctly, see discussion. 