### PR TITLE
Widening dot to operate on arrays, not just vectors.

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -325,9 +325,9 @@ Base.minimum(xs::TrackedArray; dims = :) = track(minimum, xs, dims = dims)
 
 import LinearAlgebra: dot
 
-dot(xs::TrackedVector, ys::TrackedVector) = track(dot, xs, ys)
-dot(xs::AbstractVector, ys::TrackedVector) = track(dot, xs, ys)
-dot(xs::TrackedVector, ys::AbstractVector) = track(dot, xs, ys)
+dot(xs::TrackedArray, ys::TrackedArray) = track(dot, xs, ys)
+dot(xs::AbstractArray, ys::TrackedArray) = track(dot, xs, ys)
+dot(xs::TrackedArray, ys::AbstractArray) = track(dot, xs, ys)
 
 @grad dot(xs, ys) = dot(data(xs), data(ys)), Δ -> (Δ .* ys, Δ .* xs)
 


### PR DESCRIPTION
Dot has been restricted only to vectors. When it was used on arrays, it has fell back to the default dot in LinearAlgebra, which breaks high order derivatives. This change also makes this compatible with Zygote.