### PR TITLE
Fixed a typo in meanpool

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -435,7 +435,7 @@ meanpool(x::TrackedArray, k; kw...) = track(meanpool, x, k; kw...)
 
 @grad function meanpool(x, k; kw...)
   y = meanpool(data(x), k; kw...)
-  y, Δ -> (nobacksies(:maxpool, NNlib.∇meanpool(data.((Δ, y, x))..., k; kw...)), nothing)
+  y, Δ -> (nobacksies(:meanpool, NNlib.∇meanpool(data.((Δ, y, x))..., k; kw...)), nothing)
 end
 
 # Broadcasting


### PR DESCRIPTION
@jekbradbury graciously pointed out a typo to an error message I got, which due to a particularly large stack trace I was unable to find myself.

This PR fixes the typo.