### PR TITLE
Get Tracker ready for another release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,3 +15,6 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+julia = "0.7, 1"


### PR DESCRIPTION
We should tag a new release soon, after NNlib.jl gets into Registrator, so that the version bounds on this package allow for NNlib 0.6.X