### PR TITLE
allow indexing to take kwargs

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -100,11 +100,11 @@ end
 Base.getindex(xs::TrackedArray, i...; kwargs...) = track(getindex, xs, i...; kwargs...)
 
 @grad function getindex(xs::AbstractArray, i...; kwargs...)
-  data(xs)[i...; kwargs...], function (Δ)
+  getindex(data(xs), i...; kwargs...), function (Δ)
     Δ′ = zero(xs)
-    Δ′[i...] = data(Δ)
-    (nobacksies(:getindex, Δ′), map(_->nothing, i)...)
-  end
+    setindex!(Δ′, data(Δ), i...; kwargs...)
+    (nobacksies(:getindex, Δ′), map(_->nothing, i)...)  # TODO: put kwargs here
+end
 end
 
 Base.view(x::TrackedArray, inds...; kwargs...) = track(Base.view, x, inds...; kwargs...)
@@ -112,9 +112,9 @@ Base.view(x::TrackedArray, inds...; kwargs...) = track(Base.view, x, inds...; kw
 @grad function view(x::AbstractArray, inds...; kwargs...)
     view(data(x), inds...; kwargs...), function (Δ)
         grad_output = zero(x)
-        subgrad = view(grad_output, inds...)
+        subgrad = view(grad_output, inds...; kwargs...)
         subgrad[:] = data(Δ)
-        (nobacksies(:view, grad_output), map(_->nothing, inds)...)
+        (nobacksies(:view, grad_output), map(_->nothing, inds)...)  # TODO: put kwargs here
     end
 end
 

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -101,10 +101,10 @@ Base.getindex(xs::TrackedArray, i...; kwargs...) = track(getindex, xs, i...; kwa
 
 @grad function getindex(xs::AbstractArray, i...; kwargs...)
   getindex(data(xs), i...; kwargs...), function (Δ)
-    Δ′ = zero(xs)
-    setindex!(Δ′, data(Δ), i...; kwargs...)
-    (nobacksies(:getindex, Δ′), map(_->nothing, i)...)  # TODO: put kwargs here
-end
+        Δ′ = zero(xs)
+        setindex!(Δ′, data(Δ), i...; kwargs...)
+        (nobacksies(:getindex, Δ′), map(_->nothing, i)...)
+    end
 end
 
 Base.view(x::TrackedArray, inds...; kwargs...) = track(Base.view, x, inds...; kwargs...)
@@ -114,7 +114,7 @@ Base.view(x::TrackedArray, inds...; kwargs...) = track(Base.view, x, inds...; kw
         grad_output = zero(x)
         subgrad = view(grad_output, inds...; kwargs...)
         subgrad[:] = data(Δ)
-        (nobacksies(:view, grad_output), map(_->nothing, inds)...)  # TODO: put kwargs here
+        (nobacksies(:view, grad_output), map(_->nothing, inds)...)
     end
 end
 

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -62,7 +62,7 @@ Base.copy(x::TrackedArray) = x
 
 collect(xs::TrackedArray) = xs
 
-Base.setindex!(xs::TrackedArray, v, i...) =
+Base.setindex!(xs::TrackedArray, v, i...; kwargs...) =
   error("Can't differentiate `setindex!`")
 
 back!(::TrackedArray) = error("Value is not scalar; use `back!(sum(x))` or `back!(x, Δ)`")
@@ -97,20 +97,20 @@ end
 
 # Array Stdlib
 
-Base.getindex(xs::TrackedArray, i...) = track(getindex, xs, i...)
+Base.getindex(xs::TrackedArray, i...; kwargs...) = track(getindex, xs, i...; kwargs...)
 
-@grad function getindex(xs::AbstractArray, i...)
-  data(xs)[i...], function (Δ)
+@grad function getindex(xs::AbstractArray, i...; kwargs...)
+  data(xs)[i...; kwargs...], function (Δ)
     Δ′ = zero(xs)
     Δ′[i...] = data(Δ)
     (nobacksies(:getindex, Δ′), map(_->nothing, i)...)
   end
 end
 
-Base.view(x::TrackedArray, inds...) = track(Base.view, x, inds...)
+Base.view(x::TrackedArray, inds...; kwargs...) = track(Base.view, x, inds...; kwargs...)
 
-@grad function view(x::AbstractArray, inds...)
-    view(data(x), inds...), function (Δ)
+@grad function view(x::AbstractArray, inds...; kwargs...)
+    view(data(x), inds...; kwargs...), function (Δ)
         grad_output = zero(x)
         subgrad = view(grad_output, inds...)
         subgrad[:] = data(Δ)


### PR DESCRIPTION
This is to allow `TrackedArray{NamedDimsArray}` to work right.
It should really be that a `TrackedArray{NamedDimsArray}` and a `NamedDimsArray{TrackedArray}`
work identically
but I am still working on that in  https://github.com/invenia/NamedDims.jl/pull/19
