### PR TITLE
Make jacobian work with CuArrays

### DIFF
--- a/src/back.jl
+++ b/src/back.jl
@@ -173,7 +173,11 @@ Calculate the output jacobian `J = d/dx m(x)` such that each row `i` of `J` corr
 """
 function jacobian(f, x::AbstractVector)
   y::AbstractVector, back = forward(f, x)
-  ȳ(i) = [i == j for j = 1:length(y)]
+  function ȳ(i)
+    δ = fill!(similar(y, Bool), false)
+    δ[i] = true
+    return δ
+  end
   vcat([transpose(back(ȳ(i))[1]) for i = 1:length(y)]...)
 end
 


### PR DESCRIPTION
It looks like `Tracker.jacobian` does not support CuArrays at the moment:

```julia
julia> Tracker.jacobian(identity, gpu([0.0, 0.0]))
ERROR: GPU compilation of #23(CuArrays.CuKernelState, CUDAnative.CuDeviceArray{Float32,1,CUDAnative.AS.Global}, Base.Broadcast.Broadcasted{Nothing,Tuple{Base.OneTo{Int64}},typeof(+),Tuple{Base.Broadcast.Extruded{CUDAnative.CuDeviceArray{Float32,1,CUDAnative.AS.Global},Tuple{Bool},Tuple{Int64}},Base.Broadcast.Extruded{Array{Bool,1},Tuple{Bool},Tuple{Int64}}}}) failed KernelError: passing and using non-bitstype argument

Argument 4 to your kernel function is of type Base.Broadcast.Broadcasted{Nothing,Tuple{Base.OneTo{Int64}},typeof(+),Tuple{Base.Broadcast.Extruded{CUDAnative.CuDeviceArray{Float32,1,CUDAnative.AS.Global},Tuple{Bool},Tuple{Int64}},Base.Broadcast.Extruded{Array{Bool,1},Tuple{Bool},Tuple{Int64}}}}.
That type is not isbits, and such arguments are only allowed when they are unused by the kernel.  .args is of type Tuple{Base.Broadcast.Extruded{CUDAnative.CuDeviceArray{Float32,1,CUDAnative.AS.Global},Tuple{Bool},Tuple{Int64}},Base.Broadcast.Extruded{Array{Bool,1},Tuple{Bool},Tuple{Int64}}} which is not isbits.
    .2 is of type Base.Broadcast.Extruded{Array{Bool,1},Tuple{Bool},Tuple{Int64}} which is not isbits.
      .x is of type Array{Bool,1} which is not isbits.
```

This is because `ȳ(i)` always return `Vector{Bool}`:

https://github.com/FluxML/Tracker.jl/blob/593aba6e32272bf755645ed719646a2b49beb3fe/src/back.jl#L174-L178

A fix I found (implemented in this PR) was to create the output array using `similar(y, Bool)`:

```julia
julia> using Tracker: forward

julia> function jacobian(f, x::AbstractVector)
           y::AbstractVector, back = forward(f, x)
           function ȳ(i)
               δ = fill!(similar(y, Bool), false)
               δ[i] = true
               return δ
           end
           vcat([transpose(back(ȳ(i))[1]) for i = 1:length(y)]...)
       end
jacobian (generic function with 1 method)

julia> jacobian(identity, gpu([0.0, 0.0]))
2×2 CuArray{Float32,2}:
 1.0  0.0
 0.0  1.0
```

I didn't added any tests (sorry) because Tracker's test suite does not load CuArrays.
