### PR TITLE
Fix norm for 32bit

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -345,8 +345,8 @@ Statistics.std(x::TrackedArray; dims = :, mean = Statistics.mean(x, dims = dims)
 _std(x::TrackedArray, mean, dims, corrected) = sqrt.(sum((x .- mean).^2, dims = dims) ./ (mapreduce(i -> size(x,i),*, dims) - corrected))
 _std(x::TrackedArray, mean, ::Colon, corrected) = sqrt.(sum((x .- mean).^2) ./ (length(x) - corrected))
 
-LinearAlgebra.norm(x::TrackedArray, p::Real = 2) =
-  sum(abs.(x).^p .+ eps(0f0))^(1/p) # avoid d(sqrt(x))/dx == Inf at 0
+LinearAlgebra.norm(x::TrackedArray{T}, p::Real = 2) where T =
+  (sum(abs.(x).^p) + eps(T))^(oneunit(T) / p) # avoid d(sqrt(x))/dx == Inf at 0
 
 @grad mean(xs; dims = :) = mean(data(xs), dims=dims), Δ -> (_backmean(xs,Δ,dims),)
 _backmean(xs, Δ, ::Colon) = zero(xs) .+ Δ ./ length(xs)

--- a/test/tracker.jl
+++ b/test/tracker.jl
@@ -189,6 +189,8 @@ end
 @test gradtest(dot, rand(5), rand(5))
 
 @test gradtest(norm, rand(5))
+@test gradtest(norm, zeros(5))
+@test norm(TrackedArray(rand(Float32, 5))) isa TrackedReal{Float32}
 
 @test gradtest(rand(5)) do x
   y = x.^2


### PR DESCRIPTION
Currently
```julia
norm(TrackedArray(rand(Float32, 5))) isa TrackedReal{Float64}
```
due to the term `1/p` in https://github.com/FluxML/Tracker.jl/blob/master/src/lib/array.jl#L349.

I introduced two additional changes by not broadcasting `eps` anymore and letting `eps` depend on the element type of the array (both changes decrease the deviation from `sum(abs.(x).^p)`).