### PR TITLE
Non-scalar getindex

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -102,7 +102,7 @@ Base.getindex(xs::TrackedArray, i...; kwargs...) = track(getindex, xs, i...; kwa
 @grad function getindex(xs::AbstractArray, i...; kwargs...)
   getindex(data(xs), i...; kwargs...), function (Δ)
         Δ′ = zero(xs)
-        setindex!(Δ′, data(Δ), i...; kwargs...)
+        copyto!(view(Δ′, i...; kwargs...), data(Δ))
         (nobacksies(:getindex, Δ′), map(_->nothing, i)...)
     end
 end
@@ -110,7 +110,7 @@ end
 @grad function getindex(xs::AbstractArray, i::Array...)
   data(xs)[i...], function (Δ)
     Δ′ = zero(xs)
-    @views Δ′[i...] .+= data(Δ)
+    copyto!(view(Δ′, i...), data(Δ))
     (nobacksies(:getindex, Δ′), map(_->nothing, i)...)
   end
 end


### PR DESCRIPTION
Similar to  https://github.com/FluxML/Zygote.jl/pull/256 , this aims to fix the bug described in this [discourse question](https://discourse.julialang.org/t/flux-unable-to-differentiate-an-embedding-layer/26067):

```
using Tracker
ii = rand(1:10, 2)
jj = rand(1:10, 2,2)

Tracker.gradient(x -> sum(x[ii,:]), rand(10,3))
Tracker.gradient(x -> sum(x[jj,:]), rand(10,3)) # DimensionMismatch("tried to assign 2×2×3 array to 4×3 destination")

Tracker.gradient(x -> sum(@view x[jj,:]), rand(10,3)) # fine!
```
I'm not entirely sure why `getindex` takes `kwargs...`, but had to edit that version to avoid the error above. 