### PR TITLE
Fix broadcast inference

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,9 +2,9 @@
 
 [[Adapt]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "0fac443759fa829ed8066db6cf1077d888bb6573"
+git-tree-sha1 = "95f8bda0555209f122bc796b0382ea4a3a121720"
 uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-version = "2.0.2"
+version = "2.1.0"
 
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
@@ -110,9 +110,9 @@ uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[Requires]]
 deps = ["UUIDs"]
-git-tree-sha1 = "d37400976e98018ee840e0ca4f9d20baa231dc6b"
+git-tree-sha1 = "2fc2e1ab606a5dca7bbad9036a694553c3a57926"
 uuid = "ae029012-a4dd-5104-9daa-d747884805df"
-version = "1.0.1"
+version = "1.0.3"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Tracker"
 uuid = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
-version = "0.2.11"
+version = "0.2.12"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -550,8 +550,7 @@ end
 
 @inline function ∇broadcast(f::F, args::Vararg{Any,N}) where {F,N}
   y = broadcast(f, data.(args)...)
-  eltype(y) <: Real || return y
-  eltype(y) == Bool && return y
+  (eltype(y) <: Real && eltype(y) !== Bool) || return y
   function back(Δ)
     Δargs = ntuple(i -> partial.(f, Δ, i, args...), Val(N))
     dxs = map(unbroadcast, args, Δargs)
@@ -573,7 +572,7 @@ Broadcast.BroadcastStyle(::TrackedStyle, ::BroadcastStyle) = TrackedStyle()
 broadcast_rebuild(xs) = data(xs)
 
 broadcast_rebuild(bc::Broadcasted) =
-  Broadcasted(bc.f, broadcast_rebuild.(bc.args))
+  Broadcasted(bc.f, map(broadcast_rebuild, bc.args))
 
 preprocess(x) = x
 

--- a/test/tracker.jl
+++ b/test/tracker.jl
@@ -464,6 +464,10 @@ end
     y = @inferred(f(TrackedArray(rand(5, 3))))
     @test size(y) == (5, 3)
     @test !any(y)
+
+    g(x) = @. (x < zero(x)) * x
+    y = @inferred(g(TrackedArray(rand(5, 3))))
+    @test size(y) == (5, 3)
 end
 
 end #testset

--- a/test/tracker.jl
+++ b/test/tracker.jl
@@ -458,4 +458,12 @@ end
     @test gradtest(A -> S / A, (5, 5))
 end
 
+
+@testset "broadcast" begin
+    f(x) = @. x < zero(x)
+    y = @inferred(f(TrackedArray(rand(5, 3))))
+    @test size(y) == (5, 3)
+    @test !any(y)
+end
+
 end #testset


### PR DESCRIPTION
This PR fixes an inference problem with broadcasting of TrackedArray.

On master:
```julia
julia> using Tracker, Test

julia> f(x) = @. x < zero(x)

julia> @inferred(f(Tracker.param(rand(5,4))))
ERROR: return type BitArray{2} does not match inferred return type Any
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] top-level scope at REPL[15]:1
```

With this PR:
```julia
julia> using Tracker, Test

julia> f(x) = @. x < zero(x)

julia> @inferred(f(Tracker.param(rand(5,4))))
5×4 BitArray{2}:
 0  0  0  0
 0  0  0  0
 0  0  0  0
 0  0  0  0
 0  0  0  0
```

This came up in https://github.com/TuringLang/Bijectors.jl/pull/81.