### PR TITLE
Add support for SpecialFunctions 2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Tracker"
 uuid = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
-version = "0.2.16"
+version = "0.2.17"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
@@ -24,7 +24,7 @@ MacroTools = "0.5"
 NNlib = "0.6, 0.7"
 NaNMath = "0.3"
 Requires = "0.5, 1.0"
-SpecialFunctions = "0.10, 1.0"
+SpecialFunctions = "0.10, 1, 2"
 julia = "1.3"
 
 [extras]


### PR DESCRIPTION
This PR adds support for SpecialFunctions 2. The only breaking change in this release was the removal of `factorial(x::Number)` which was type piracy (it's defined for integers in Julia base). Since Tracker does not use `factorial` it should not be affected by this change.