### PR TITLE
Update `NNlib.softmax` gradients

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,8 +20,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1'
           - '1.3'
+          - '1.6' # LTS
+          - '1'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Tracker"
 uuid = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
-version = "0.2.19"
+version = "0.2.20"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
@@ -23,7 +23,7 @@ DiffRules = "1.4"
 ForwardDiff = "0.10"
 LogExpFunctions = "0.3"
 MacroTools = "0.5"
-NNlib = "0.6, 0.7, 0.8"
+NNlib = "0.7.18, 0.8"  # 0.7.18 is the last version which supports Julia 1.3
 NaNMath = "0.3, 1"
 Requires = "0.5, 1.0"
 SpecialFunctions = "0.10, 1, 2"

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -171,9 +171,7 @@ end
 
 for i = 0:2, c = combinations([:AbstractArray, :TrackedArray, :Number], i), f = [:hcat, :vcat]
   cnames = map(_ -> gensym(), c)
-  @eval Base.$f($([:($x::$c) for (x, c) in zip(cnames, c)]...), x::Union{TrackedArray,TrackedReal}, xs::AbstractArray...) =
-    track($f, $(cnames...), x, xs...)
-  @eval Base.$f($([:($x::$c) for (x, c) in zip(cnames, c)]...), x::Union{TrackedArray,TrackedReal}, xs::Number...) =
+  @eval Base.$f($([:($x::$c) for (x, c) in zip(cnames, c)]...), x::Union{TrackedArray,TrackedReal}, xs::Union{AbstractArray,Number}...) =
     track($f, $(cnames...), x, xs...)
 end
 

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -171,7 +171,9 @@ end
 
 for i = 0:2, c = combinations([:AbstractArray, :TrackedArray, :Number], i), f = [:hcat, :vcat]
   cnames = map(_ -> gensym(), c)
-  @eval Base.$f($([:($x::$c) for (x, c) in zip(cnames, c)]...), x::Union{TrackedArray,TrackedReal}, xs::Union{AbstractArray,Number}...) =
+  @eval Base.$f($([:($x::$c) for (x, c) in zip(cnames, c)]...), x::Union{TrackedArray,TrackedReal}, xs::AbstractArray...) =
+    track($f, $(cnames...), x, xs...)
+  @eval Base.$f($([:($x::$c) for (x, c) in zip(cnames, c)]...), x::Union{TrackedArray,TrackedReal}, xs::Number...) =
     track($f, $(cnames...), x, xs...)
 end
 

--- a/test/tracker.jl
+++ b/test/tracker.jl
@@ -129,9 +129,11 @@ end
 
   @testset "scalars" begin
     @test vcat(param([1, 2, 3]), 1) isa TrackedArray
+    @test vcat(param(1), 2) isa TrackedArray
+
+    # These two are ambiguity errors on Julia 1.8
     @test vcat(1, param([1, 2, 3])) isa TrackedArray
     @test hcat(1, param([1 2 3;])) isa TrackedArray
-    @test vcat(param(1), 2) isa TrackedArray
   end
 
 end

--- a/test/tracker.jl
+++ b/test/tracker.jl
@@ -129,11 +129,9 @@ end
 
   @testset "scalars" begin
     @test vcat(param([1, 2, 3]), 1) isa TrackedArray
-    @test vcat(param(1), 2) isa TrackedArray
-
-    # These two are ambiguity errors on Julia 1.8
     @test vcat(1, param([1, 2, 3])) isa TrackedArray
     @test hcat(1, param([1 2 3;])) isa TrackedArray
+    @test vcat(param(1), 2) isa TrackedArray
   end
 
 end

--- a/test/tracker.jl
+++ b/test/tracker.jl
@@ -10,7 +10,9 @@ using Random
 
 gradtest(f, xs::AbstractArray...) = gradcheck((xs...) -> sum(sin.(f(xs...))), xs...)
 gradtest(f, dims...) = gradtest(f, rand.(Float64, dims)...)
-@testset "Tracker" begin
+
+@testset "Tracker" begin # overall testset, rest of the file
+
 @test gradtest((x, W, b) -> σ.(W*x .+ b), 5, (2,5), 2)
 @test gradtest((x, W) -> σ.(W*x), 5, (2,5))
 @test gradtest((x, W, b) -> σ.(W*x .+ b), (5,3), (2,5), 2)
@@ -478,4 +480,4 @@ end
     @test size(y) == (5, 3)
 end
 
-end #testset
+end # overall testset


### PR DESCRIPTION
This should use the functions from https://github.com/FluxML/NNlib.jl/pull/393 when available. But Tracker still supports Julia 1.3, which latest NNlib does not, so it can't just demand that version. Instead it checks. 

The fallback is still an upgrade, using methods added in https://github.com/FluxML/NNlib.jl/pull/250 which use the result of the forward pass instead of re-computing it. 