### PR TITLE
Remove dual hack

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Tracker"
 uuid = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
-version = "0.2.21"
+version = "0.2.22"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/lib/real.jl
+++ b/src/lib/real.jl
@@ -103,13 +103,6 @@ import Base:^
 
 ^(a::TrackedReal, b::Integer) = track(^, a, b)
 
-# Hack for conversions
-
-using ForwardDiff: Dual
-
-(T::Type{<:Real})(x::Dual) = Dual(T(x.value), map(T, x.partials.values))
-(Dual{T,V,N})(x::Dual) where {T,V,N} = invoke(Dual{T,V,N}, Tuple{Number}, x)
-
 # Tuples
 
 struct TrackedTuple{T<:Tuple}

--- a/test/tracker.jl
+++ b/test/tracker.jl
@@ -339,7 +339,8 @@ end
   end
 end
 
-@test gradtest(x -> Float64.(x), 5)
+# Upstream issue: https://github.com/JuliaDiff/ForwardDiff.jl/pull/538
+@test_broken gradtest(x -> Float64.(x), 5)
 
 @testset "equality & order" begin
     # TrackedReal


### PR DESCRIPTION
This PR removes a "Hack for conversions", as it's called in the comment.

The problem is that
- it is a very severe form of type piracy that completely changes the behaviour of `ForwardDiff.Dual`s when Tracker is loaded
- it causes downstream issues (see e.g. https://github.com/SciML/SciMLSensitivity.jl/issues/724)
- the underlying issue should not be addressed here but upstream (see https://github.com/JuliaDiff/ForwardDiff.jl/pull/538)
- the definition messes up the dual number tags since it just sets them to `Nothing` (cf. with the definition in the ForwardDiff PR), and hence the following example still does not work but only fails with a different error message:

```julia
julia> using ForwardDiff

julia> ForwardDiff.derivative(x -> Float64(x), 5)
ERROR: MethodError: no method matching Float64(::ForwardDiff.Dual{ForwardDiff.Tag{var"#3#4", Int64}, Int64, 1})
Closest candidates are:
  (::Type{T})(::Real, ::RoundingMode) where T<:AbstractFloat at rounding.jl:200
  (::Type{T})(::T) where T<:Number at boot.jl:772
  (::Type{T})(::AbstractChar) where T<:Union{AbstractChar, Number} at char.jl:50
  ...
Stacktrace:
 [1] (::var"#3#4")(x::ForwardDiff.Dual{ForwardDiff.Tag{var"#3#4", Int64}, Int64, 1})
   @ Main ./REPL[3]:1
 [2] derivative(f::var"#3#4", x::Int64)
   @ ForwardDiff ~/.julia/packages/ForwardDiff/pDtsf/src/derivative.jl:14
 [3] top-level scope
   @ REPL[3]:1

julia> using Tracker

julia> ForwardDiff.derivative(x -> Float64(x), 5)
ERROR: Cannot determine ordering of Dual tags Nothing and ForwardDiff.Tag{var"#5#6", Int64}
Stacktrace:
 [1] ≺(a::Type, b::Type)
   @ ForwardDiff ~/.julia/packages/ForwardDiff/pDtsf/src/dual.jl:54
 [2] partials
   @ ~/.julia/packages/ForwardDiff/pDtsf/src/dual.jl:108 [inlined]
 [3] extract_derivative
   @ ~/.julia/packages/ForwardDiff/pDtsf/src/derivative.jl:84 [inlined]
 [4] derivative(f::var"#5#6", x::Int64)
   @ ForwardDiff ~/.julia/packages/ForwardDiff/pDtsf/src/derivative.jl:14
 [5] top-level scope
   @ REPL[5]:1
```