### PR TITLE
Overload NNlib.within_gradient

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Tracker"
 uuid = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
-version = "0.2.22"
+version = "0.2.23"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
@@ -26,7 +26,7 @@ Functors = "0.3.0"
 ForwardDiff = "0.10"
 LogExpFunctions = "0.3"
 MacroTools = "0.5"
-NNlib = "0.8"
+NNlib = "0.8.14"
 NaNMath = "1"
 Optimisers = "0.2.9"
 Requires = "1.0"

--- a/src/Tracker.jl
+++ b/src/Tracker.jl
@@ -4,6 +4,7 @@ using MacroTools
 using MacroTools: @q, @forward
 
 using DiffRules
+using ForwardDiff
 import LogExpFunctions
 import NaNMath
 import SpecialFunctions

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -472,7 +472,10 @@ Base.:*(x::TrackedMatrix, y::Diagonal) = track(*, x, y)
 
 using NNlib
 import NNlib: softmax, ∇softmax, logsoftmax, ∇logsoftmax, conv, ∇conv_data, depthwiseconv, maxpool, meanpool
-import NNlib: DenseConvDims, DepthwiseConvDims, PoolDims
+import NNlib: DenseConvDims, DepthwiseConvDims, PoolDims, within_gradient
+
+within_gradient(::TrackedArray) = true
+within_gradient(::TrackedReal) = true
 
 softmax(xs::TrackedArray; dims=1) = track(softmax, xs; dims=dims)
 

--- a/src/lib/real.jl
+++ b/src/lib/real.jl
@@ -8,6 +8,8 @@ TrackedReal(x::Real) = TrackedReal(x, Tracked{typeof(x)}(Call(), zero(x)))
 data(x::TrackedReal) = x.data
 tracker(x::TrackedReal) = x.tracker
 
+ForwardDiff.value(x::TrackedReal) = x.data
+
 track(f::Call, x::Real) = TrackedReal(x, Tracked{typeof(x)}(f, zero(x)))
 
 function back!(x::TrackedReal; once = true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,4 +33,11 @@ Optimisers.trainable(x::TwoThirds) = (a = x.a,)
   @test g == (val = 6.0, grad = ((a = [1.0], b = nothing, c = nothing),))
 end
 
+using NNlib
+@testset "NNlib.within_gradient" begin
+  f_good(x) = NNlib.within_gradient(x) ? 10x : x
+  @test gradient(f_good, 1.0)[1] == 10
+  @test gradient(x -> sum(f_good(x)), [1.0])[1] == [10]
+end
+
 end  # overall @testset

--- a/test/tracker.jl
+++ b/test/tracker.jl
@@ -4,7 +4,7 @@ using NNlib: conv, ∇conv_data, depthwiseconv
 using PDMats
 using Printf: @sprintf
 using LinearAlgebra: diagm, dot, LowerTriangular, norm, det, logdet, logabsdet, I, Diagonal
-using Statistics: mean, std
+using Statistics: mean, std, var
 using Random
 # using StatsBase
 
@@ -137,7 +137,7 @@ end
     @test hcat(1, param([1 2 3;])) isa TrackedArray
     @test vcat(param(1), 2) isa TrackedArray
   end
-  
+
   @testset "ambiguities" begin
     @test vcat(param([1, 2, 3]), [2,3]) isa TrackedArray
     @test vcat(param([1, 2, 3]), [2.0, 3.0]) isa TrackedArray
@@ -229,6 +229,12 @@ end
 @test gradtest(x -> std(x), rand(5,5))
 @test gradtest(x -> std(x, dims = 1), rand(5,5))
 @test gradtest(x -> std(x, dims = 1, corrected = false), rand(5,5))
+
+@test gradtest(x -> var(x), rand(5,5))
+@test gradtest(x -> var(x, dims = 1), rand(5,5))
+@test gradtest(x -> var(x, dims = 1, corrected = false), rand(5,5))
+x55 = rand(5,5)
+@test gradtest(x -> var(x, dims = 2, mean = mean(x55; dims=2)), x55)
 
 @test gradtest((x, y) -> x .* y, rand(5), rand(5))
 @test gradtest(dot, rand(5), rand(5))


### PR DESCRIPTION
Uses https://github.com/FluxML/NNlib.jl/pull/434

Does not solve https://github.com/FluxML/Tracker.jl/issues/133 but the error is different:
```julia
julia> using Flux, Zygote, Tracker

julia> bn = BatchNorm(2); x = rand(Float32, 2, 3);

julia> sum(deepcopy(bn)(x))
2.1757803f0

julia> bn.active === nothing
true

julia> bn.active = false
false

julia> _bn = deepcopy(bn); Zygote.withgradient(sum∘_bn, x)[1]
2.1757803f0

julia> _bn = deepcopy(bn); Tracker.withgradient(sum∘_bn, x)[1]
2.1757803f0

julia> bn.active = true
true

julia> _bn = deepcopy(bn); Zygote.withgradient(sum∘_bn, x)[1]
-2.0489097f-7

julia> _bn = deepcopy(bn); Tracker.gradient(sum∘_bn, x)[1]
ERROR: MethodError: no method matching Float32(::Tracker.TrackedReal{Float32})
...
Stacktrace:
  [1] convert(#unused#::Type{Float32}, x::Tracker.TrackedReal{Float32})
    @ Base ./number.jl:7
  [2] setindex!
    @ ./array.jl:971 [inlined]
...
  [9] materialize!
    @ ./broadcast.jl:881 [inlined]
 [10] accum!(x::Matrix{Float32}, Δ::Matrix{Tracker.TrackedReal{Float32}})
    @ Tracker ~/.julia/packages/Tracker/a9oj5/src/back.jl:45
 [11] back(x::Tracker.Tracked{Matrix{Float32}}, Δ::Matrix{Tracker.TrackedReal{Float32}}, once::Bool)
    @ Tracker ~/.julia/packages/Tracker/a9oj5/src/back.jl:48
...
 [22] back(x::Tracker.Tracked{Matrix{Tracker.TrackedReal{Float32}}}, Δ::Matrix{Tracker.TrackedReal{Float32}}, once::Bool)

```

Does not make the example from https://github.com/FluxML/Flux.jl/issues/2122 work, but perhaps the failure is unrelated:

```julia
julia> let
       using Flux
       using Random
       Random.seed!(123)

       model = Chain(
                 Conv((3, 3), 3 => 5, pad=1, bias=false), 
                 BatchNorm(5, relu), 
                 Conv((3, 3), 5 => 3, stride=16),
               )
       image = rand(Float32, 224, 224, 3, 1);
       @show sum(model(image));

       loss(m, x) = sum(m(x))

       opt = Flux.setup(Flux.Adam(0.001f0,  (0.9f0, 0.999f0), 1.1920929f-7), model)

       val, grads = Tracker.withgradient(model) do m
           loss(m, image)
       end

       Flux.update!(opt, model, grads[1])
       @show loss(model, image);
       end;
sum(model(image)) = -0.33076355f0
ERROR: UndefRefError: access to undefined reference
Stacktrace:
  [1] getindex
    @ ./essentials.jl:14 [inlined]
  [2] conv_direct!(y::Array{Tracker.TrackedReal{Float32}, 5}, x::Array{Tracker.TrackedReal{Float32}, 5}, w::Array{Float32, 5}, cdims::DenseConvDims{3, 3, 3, 6, 3}, ::Val{(3, 3, 1)}, ::Val{3}, ::Val{(0, 0, 0, 0, 0, 0)}, ::Val{(1, 1, 1)}, ::Val{(16, 16, 1)}, fk::Val{false}; alpha::Tracker.TrackedReal{Float32}, beta::Bool)
    @ NNlib ~/.julia/packages/NNlib/QJIIj/src/impl/conv_direct.jl:111
  [3] kwcall(::NamedTuple{(:alpha, :beta), Tuple{Tracker.TrackedReal{Float32}, Bool}}, ::typeof(NNlib.conv_direct!), y::Array{Tracker.TrackedReal{Float32}, 5}, x::Array{Tracker.TrackedReal{Float32}, 5}, w::Array{Float32, 5}, cdims::DenseConvDims{3, 3, 3, 6, 3}, ::Val{(3, 3, 1)}, ::Val{3}, ::Val{(0, 0, 0, 0, 0, 0)}, ::Val{(1, 1, 1)}, ::Val{(16, 16, 1)}, fk::Val{false})
    @ NNlib ~/.julia/packages/NNlib/QJIIj/src/impl/conv_direct.jl:59
  [4] conv_direct!(y::Array{Tracker.TrackedReal{Float32}, 5}, x::Array{Tracker.TrackedReal{Float32}, 5}, w::Array{Float32, 5}, cdims::DenseConvDims{3, 3, 3, 6, 3}; alpha::Tracker.TrackedReal{Float32}, beta::Bool)
    @ NNlib ~/.julia/packages/NNlib/QJIIj/src/impl/conv_direct.jl:50
  [5] conv_direct!
    @ ~/.julia/packages/NNlib/QJIIj/src/impl/conv_direct.jl:47 [inlined]
  [6] #conv!#301
    @ ~/.julia/packages/NNlib/QJIIj/src/conv.jl:288 [inlined]
  [7] conv!
    @ ~/.julia/packages/NNlib/QJIIj/src/conv.jl:280 [inlined]
  [8] conv!(y::Array{Tracker.TrackedReal{Float32}, 4}, x::Array{Tracker.TrackedReal{Float32}, 4}, w::Array{Float32, 4}, cdims::DenseConvDims{2, 2, 2, 4, 2}; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ NNlib ~/.julia/packages/NNlib/QJIIj/src/conv.jl:145
  [9] conv!
    @ ~/.julia/packages/NNlib/QJIIj/src/conv.jl:140 [inlined]
 [10] conv(x::Array{Tracker.TrackedReal{Float32}, 4}, w::Array{Float32, 4}, cdims::DenseConvDims{2, 2, 2, 4, 2}; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ NNlib ~/.julia/packages/NNlib/QJIIj/src/conv.jl:88
 [11] conv
    @ ~/.julia/packages/NNlib/QJIIj/src/conv.jl:83 [inlined]
 [12] #_forward#636
    @ ~/.julia/packages/Tracker/a9oj5/src/lib/array.jl:520 [inlined]
 [13] _forward
    @ ./none:0 [inlined]
 [14] #track#1
    @ ~/.julia/packages/Tracker/a9oj5/src/Tracker.jl:58 [inlined]
 [15] track
    @ ~/.julia/packages/Tracker/a9oj5/src/Tracker.jl:57 [inlined]
 [16] #conv#633
    @ ~/.julia/packages/Tracker/a9oj5/src/lib/array.jl:516 [inlined]
 [17] conv
    @ ~/.julia/packages/Tracker/a9oj5/src/lib/array.jl:516 [inlined]
 [18] (::Conv{2, 4, typeof(identity), TrackedArray{…,Array{Float32, 4}}, TrackedArray{…,Vector{Float32}}})(x::TrackedArray{…,Array{Tracker.TrackedReal{Float32}, 4}})
    @ Flux ~/.julia/dev/Flux/src/layers/conv.jl:200
 [19] macro expansion
    @ ~/.julia/dev/Flux/src/layers/basic.jl:53 [inlined]
 [20] _applychain(layers::Tuple{Conv{2, 4, typeof(identity), TrackedArray{…,Array{Float32, 4}}, Bool}, BatchNorm{typeof(relu), TrackedArray{…,Vector{Float32}}, Float32, Vector{Float32}}, Conv{2, 4, typeof(identity), TrackedArray{…,Array{Float32, 4}}, TrackedArray{…,Vector{Float32}}}}, x::Array{Float32, 4})
    @ Flux ~/.julia/dev/Flux/src/layers/basic.jl:53
 [21] Chain
    @ ~/.julia/dev/Flux/src/layers/basic.jl:51 [inlined]
 [22] (::var"#loss#31")(m::Chain{Tuple{Conv{2, 4, typeof(identity), TrackedArray{…,Array{Float32, 4}}, Bool}, BatchNorm{typeof(relu), TrackedArray{…,Vector{Float32}}, Float32, Vector{Float32}}, Conv{2, 4, typeof(identity), TrackedArray{…,Array{Float32, 4}}, TrackedArray{…,Vector{Float32}}}}}, x::Array{Float32, 4})
    @ Main ./REPL[28]:14
 [23] (::var"#30#32"{var"#loss#31", Array{Float32, 4}})(m::Chain{Tuple{Conv{2, 4, typeof(identity), TrackedArray{…,Array{Float32, 4}}, Bool}, BatchNorm{typeof(relu), TrackedArray{…,Vector{Float32}}, Float32, Vector{Float32}}, Conv{2, 4, typeof(identity), TrackedArray{…,Array{Float32, 4}}, TrackedArray{…,Vector{Float32}}}}})
    @ Main ./REPL[28]:19
 [24] withgradient(f::Function, xs::Chain{Tuple{Conv{2, 4, typeof(identity), Array{Float32, 4}, Bool}, BatchNorm{typeof(relu), Vector{Float32}, Float32, Vector{Float32}}, Conv{2, 4, typeof(identity), Array{Float32, 4}, Vector{Float32}}}})
    @ Tracker ~/.julia/packages/Tracker/a9oj5/src/back.jl:218
 [25] top-level scope
    @ REPL[28]:18
```

Edit: fixed, closes #133, closes #137