### PR TITLE
Remove `_zero` workaround

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Tracker"
 uuid = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
-version = "0.2.23"
+version = "0.2.24"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/lib/real.jl
+++ b/src/lib/real.jl
@@ -72,10 +72,6 @@ for f in :[rand, randn, randexp].args
   @eval Random.$f(rng::AbstractRNG,::Type{TrackedReal{T}}) where {T} = param(rand(rng,T))
 end
 
-# Work around zero(π) not working, for some reason
-_zero(::Irrational) = nothing
-_zero(x) = zero(x)
-
 for (M, f, arity) in DiffRules.diffrules(; filter_modules=nothing)
   if !(isdefined(@__MODULE__, M) && isdefined(getfield(@__MODULE__, M), f))
     @warn "$M.$f is not available and hence rule for it can not be defined"
@@ -91,8 +87,8 @@ for (M, f, arity) in DiffRules.diffrules(; filter_modules=nothing)
     da, db = DiffRules.diffrule(M, f, :a, :b)
     @eval begin
       @grad $Mf(a::TrackedReal, b::TrackedReal) = $Mf(data(a), data(b)), Δ -> (Δ * $da, Δ * $db)
-      @grad $Mf(a::TrackedReal, b::Real) = $Mf(data(a), b), Δ -> (Δ * $da, _zero(b))
-      @grad $Mf(a::Real, b::TrackedReal) = $Mf(a, data(b)), Δ -> (_zero(a), Δ * $db)
+      @grad $Mf(a::TrackedReal, b::Real) = $Mf(data(a), b), Δ -> (Δ * $da, zero(b))
+      @grad $Mf(a::Real, b::TrackedReal) = $Mf(a, data(b)), Δ -> (zero(a), Δ * $db)
       $Mf(a::TrackedReal, b::TrackedReal)  = track($Mf, a, b)
       $Mf(a::TrackedReal, b::Real) = track($Mf, a, b)
       $Mf(a::Real, b::TrackedReal) = track($Mf, a, b)


### PR DESCRIPTION
I was looking at usage of `Irrational` in packages (https://juliahub.com/ui/Search?q=Irrational&type=symbols&u=use&t=type), to estimate how breaking https://github.com/JuliaMath/IrrationalConstants.jl/pull/19 (motivated by https://github.com/JuliaLang/julia/issues/46531) will be. Tracker showed up in the list of packages but it seems the `_zero` workaround is not needed anymore since in recent Julia versions `zero` is defined for `AbstractIrrational`: https://github.com/JuliaLang/julia/blob/f9720dc2ebd6cd9e3086365f281e62506444ef37/base/irrationals.jl#L148-L149