### PR TITLE
Add derivative of `logabsgamma`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Tracker"
 uuid = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
-version = "0.2.24"
+version = "0.2.25"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/lib/real.jl
+++ b/src/lib/real.jl
@@ -149,3 +149,13 @@ end
 
 collectmemaybe(xs::AbstractArray{>:TrackedReal}) = collect(xs)
 collectmemaybe(xs::AbstractArray{<:TrackedReal}) = collect(xs)
+
+# `logabsgamma` returns a tuple and hence its derivative is not defined in DiffRules
+SpecialFunctions.logabsgamma(x::TrackedReal) = track(SpecialFunctions.logabsgamma, x)
+@grad function SpecialFunctions.logabsgamma(x::Real)
+  data_x = data(x)
+  function logabsgamma_pullback(Δ)
+    return (SpecialFunctions.digamma(data_x) * first(Δ),)
+  end
+  return SpecialFunctions.logabsgamma(data_x), logabsgamma_pullback
+end

--- a/test/tracker.jl
+++ b/test/tracker.jl
@@ -2,6 +2,7 @@ using Tracker, Test, NNlib
 using Tracker: TrackedReal, gradient, gradcheck, grad, checkpoint, forwarddiff
 using NNlib: conv, ∇conv_data, depthwiseconv
 using PDMats
+using SpecialFunctions: logabsgamma
 using Printf: @sprintf
 using LinearAlgebra: diagm, dot, LowerTriangular, norm, det, logdet, logabsdet, I, Diagonal
 using Statistics: mean, std, var
@@ -504,3 +505,7 @@ end
     @test size(y) == (5, 3)
 end
 
+@testset "logabsgamma" begin
+  @test gradcheck(x -> logabsgamma(only(x))[1], rand(1))
+  @test gradcheck(x -> logabsgamma(only(x))[2], rand(1))
+end


### PR DESCRIPTION
This PR adds a derivative for `logabsgamma` (basically a copy of https://github.com/JuliaDiff/ForwardDiff.jl/pull/585 for Tracker). The derivative cannot be defined in DiffRules since the function returns a tuple.

Currently:
```julia
julia> Tracker.gradient(x -> logabsgamma(x)[1], rand())
ERROR: MethodError: no method matching _logabsgamma(::Tracker.TrackedReal{Float64})
...

julia> Tracker.gradient(x -> logabsgamma(x)[2], rand())
ERROR: MethodError: no method matching _logabsgamma(::Tracker.TrackedReal{Float64})
...
```

With this PR:
```julia
julia> Tracker.gradient(x -> logabsgamma(x)[1], rand())
(-1.808248603306234 (tracked),)

julia> Tracker.gradient(x -> logabsgamma(x)[2], rand())
(0.0 (tracked),)
```