### PR TITLE
Simple fix for `kron(::AbstractVector)`

### DIFF
--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -312,6 +312,7 @@ function _kron(mat1::AbstractMatrix,mat2::AbstractMatrix)
 
     return reshape(mat1_rsh.*mat2_rsh, (m1*m2,n1*n2))
 end
+_kron(a::AbstractVector, b::AbstractVector) = vec(_kron(reshape(a, :, 1), reshape(b, :, 1)))
 
 Base.kron(a::TrackedMatrix, b::TrackedMatrix)  = _kron(a, b)
 Base.kron(a::TrackedMatrix, b::AbstractMatrix) = _kron(a, b)

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -314,9 +314,9 @@ function _kron(mat1::AbstractMatrix,mat2::AbstractMatrix)
 end
 _kron(a::AbstractVector, b::AbstractVector) = vec(_kron(reshape(a, :, 1), reshape(b, :, 1)))
 
-Base.kron(a::TrackedMatrix, b::TrackedMatrix)  = _kron(a, b)
-Base.kron(a::TrackedMatrix, b::AbstractMatrix) = _kron(a, b)
-Base.kron(a::AbstractMatrix, b::TrackedMatrix) = _kron(a, b)
+Base.kron(a::TrackedVecOrMat, b::TrackedVecOrMat)  = _kron(a, b)
+Base.kron(a::TrackedVecOrMat, b::AbstractVecOrMat) = _kron(a, b)
+Base.kron(a::AbstractVecOrMat, b::TrackedVecOrMat) = _kron(a, b)
 
 
 inv(A::TrackedArray) = Tracker.track(inv, A)


### PR DESCRIPTION
Copying over the change from https://github.com/FluxML/Zygote.jl/pull/1378. This should make downstream tests green again for many libraries, cc @avik-pal.

### PR Checklist

~~- [ ] Tests are added~~
~~- [ ] Documentation, if applicable~~
