### PR TITLE
remove show method for `TrackedArray` type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Tracker"
 uuid = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
-version = "0.2.30"
+version = "0.2.31"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -41,11 +41,6 @@ Base.convert(T::Type{<:TrackedArray}, x::TrackedArray) =
 Base.convert(::Type{<:TrackedArray{T,N,A}}, x::AbstractArray) where {T,N,A} =
   TrackedArray(convert(A, x))
 
-Base.show(io::IO, t::Type{TrackedArray{T,N,A}}) where {T,N,A<:AbstractArray{T,N}} =
-  @isdefined(A) ?
-    print(io, "TrackedArray{…,$A}") :
-    invoke(show, Tuple{IO,DataType}, io, t)
-
 function Base.summary(io::IO, x::TrackedArray)
   print(io, "Tracked ")
   summary(io, data(x))


### PR DESCRIPTION
This method causes horrible invalidations and causes havoc in loading times and compilation time after Tracker.jl is loaded.

For example, loading Enzyme.jl goes from 0.5 seconds to 22 seconds if Tracker.jl is loaded first.

The printing of types should hopefully have been improved enough in https://github.com/JuliaLang/julia/pull/49795 that this is not needed.
