### PR TITLE
fix: random number generation

### DIFF
--- a/src/lib/real.jl
+++ b/src/lib/real.jl
@@ -67,7 +67,7 @@ Base.promote_rule(::Type{TrackedReal{S}},::Type{T}) where {S,T} =
 using Random
 
 for f in :[rand, randn, randexp].args
-  @eval Random.$f(rng::AbstractRNG,::Type{TrackedReal{T}}) where {T} = param(rand(rng,T))
+  @eval Random.$f(rng::AbstractRNG,::Type{TrackedReal{T}}) where {T} = param(Random.$f(rng,T))
 end
 
 for (M, f, arity) in DiffRules.diffrules(; filter_modules=nothing)

--- a/test/tracker.jl
+++ b/test/tracker.jl
@@ -509,3 +509,19 @@ end
   @test gradcheck(x -> logabsgamma(only(x))[1], rand(1))
   @test gradcheck(x -> logabsgamma(only(x))[2], rand(1))
 end
+
+@testset "rand" begin
+  Random.seed!(1234)
+  n_samples = 10^6
+  x = [Random.rand(Tracker.TrackedReal{Float64}) for i in 1:n_samples]
+  @test isapprox(mean(x), 0.5, atol=1e-2, rtol=0)
+  @test isapprox(var(x), 1/12, atol=1e-2, rtol=0)
+
+  x = [Random.randn(Tracker.TrackedReal{Float64}) for i in 1:n_samples]
+  @test isapprox(mean(x), 0., atol=1e-2, rtol=0)
+  @test isapprox(var(x), 1., atol=1e-2, rtol=0)
+
+  x = [Random.randexp(Tracker.TrackedReal{Float64}) for i in 1:n_samples]
+  @test isapprox(mean(x), 1., atol=1e-2, rtol=0)
+  @test isapprox(var(x), 1., atol=1e-2, rtol=0)
+end


### PR DESCRIPTION
Fixes #158.

```
x = [Random.randn(Random.default_rng(), Tracker.TrackedReal{Float64}) for i in 1:10^6]
Distributions.mean(x) 
Distributions.std(x)
```
now produces a normal sample, and not a uniform sample as before.