### PR TITLE
Allow `withgradient` to pass aux info, and add `@grad dropout`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Tracker"
 uuid = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
-version = "0.2.31"
+version = "0.2.32"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/back.jl
+++ b/src/back.jl
@@ -191,10 +191,15 @@ However, it differs from `gradient` in several other respects:
   returns a tree-like gradient matching the shape of a Flux model.
   This recursion obeys restrictions imposed by `Optimisers.trainable`, if defined.
 * Only objects satisfying `Optimisers.isnumeric` are regarded as parameters,
-  thus in particular integers are ignored.
+  thus in particular arrays of integers are ignored.
 * Returns plain arrays, not tracked. Uses `nothing` as a strong zero gradient, like Zygote.
+* Allows you to capture auxillary outputs, in addition to the scalar
+  used by `gradient`. To do this, `f` must return a Tuple or NamedTuple.
+  Then it calculates `grad = gradient(first∘f, args...)
+  but returns the whole `val = f(args...)`:
 
 # Examples
+
 ```
 julia> nt = (vec = [1.0, 2.0], mat = [4.0;;], fun = sin);
 
@@ -216,10 +221,12 @@ julia> withgradient(model, rand(Float32, 2)) do m, x
 function withgradient(f, xs...)
     pxs = fmap(param, xs; exclude = isnumeric, walk = _trainable_walk)
     l = f(pxs...)
-    losscheck(l)
-    l isa TrackedReal || return (val = l, grad = nothing)
-    @interrupts back!(l)
-    (val = data(l), grad = rec_grad(pxs))
+    l1 = l isa Union{Tuple, NamedTuple} ? first(l) : l
+    val = l isa Union{Tuple, NamedTuple} ? map(data, l) : l
+    losscheck(l1)
+    l1 isa TrackedReal || return (; val, grad = map(_ -> nothing, xs))
+    @interrupts back!(l1)
+    (; val, grad = rec_grad(pxs))
 end
 
 function _trainable_walk(f, x)

--- a/src/back.jl
+++ b/src/back.jl
@@ -222,7 +222,7 @@ function withgradient(f, xs...)
     pxs = fmap(param, xs; exclude = isnumeric, walk = _trainable_walk)
     l = f(pxs...)
     l1 = l isa Union{Tuple, NamedTuple} ? first(l) : l
-    val = l isa Union{Tuple, NamedTuple} ? map(data, l) : l
+    val = l isa Union{Tuple, NamedTuple} ? fmap(data, l) : data(l)
     losscheck(l1)
     l1 isa TrackedReal || return (; val, grad = map(_ -> nothing, xs))
     @interrupts back!(l1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,10 @@ Optimisers.trainable(x::TwoThirds) = (a = x.a,)
   @test withgradient((x, p) -> sum(abs2, x.vec) ^ p, nt, 2) == (val = 25.0, grad = ((vec = [20.0, 40.0], mat = [0.0;;], fun = nothing), nothing))
 
   @test withgradient(x -> sum(x.v), (v = [1, 2], w = [3.0])) == (val = 3, grad = nothing)
+  @test withgradient(x -> (sum(x.v), x.v), (v = [1, 2], w = [3.0])) == (val = 3, grad = 
+nothing)
+  @test withgradient(x -> (sum=sum(x.v), aux=missing), (v = [1, 2], w = [3.0])) == (val = 3, 
+grad = nothing)
 
   m = TwoThirds([1.0], [2.0], [3.0])  # only the first should be tracked, but all should survive
   g = withgradient(m -> only(m.a::AbstractVector + m.b::Vector + m.c::Vector), m)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,11 +26,11 @@ Optimisers.trainable(x::TwoThirds) = (a = x.a,)
   nt = (vec = [1.0, 2.0], mat = [4.0;;], fun = sin);
   @test withgradient((x, p) -> sum(abs2, x.vec) ^ p, nt, 2) == (val = 25.0, grad = ((vec = [20.0, 40.0], mat = [0.0;;], fun = nothing), nothing))
 
-  @test withgradient(x -> sum(x.v), (v = [1, 2], w = [3.0])) == (val = 3, grad = nothing)
-  @test withgradient(x -> (sum(x.v), x.v), (v = [1, 2], w = [3.0])) == (val = 3, grad = 
-nothing)
-  @test withgradient(x -> (sum=sum(x.v), aux=missing), (v = [1, 2], w = [3.0])) == (val = 3, 
-grad = nothing)
+  @test withgradient(x -> sum(x.v), (v = [1, 2], w = [3.0])) == (val = 3, grad = (nothing,))
+  @test withgradient(x -> (sum(x.v), x.v), (v = [1, 2], w = [3.0])) == (val = (3, [1, 2]),
+    grad = (nothing,))
+  @test withgradient(x -> (sum=sum(x.v), aux=33), (v = [1, 2], w = [3.0])) ==
+    (val = (sum=3, aux=33), grad = (nothing,))
 
   m = TwoThirds([1.0], [2.0], [3.0])  # only the first should be tracked, but all should survive
   g = withgradient(m -> only(m.a::AbstractVector + m.b::Vector + m.c::Vector), m)

--- a/test/tracker.jl
+++ b/test/tracker.jl
@@ -40,7 +40,7 @@ end
 @test gradtest(x -> logsoftmax(x; dims = 1).*(1:3), (3,5))
 @test gradtest(x -> logsoftmax(x; dims = 2).*(1:3), (3,5))
 
-RNG = NNlib.Random.Xoshiro(1)
+RNG = NNlib.Random.MersenneTwister(1)
 @test gradtest(x -> dropout(copy(RNG), x, 0.5), 10)
 @test gradtest(x -> dropout(copy(RNG), x, 0.4; dims=1), (8, 9))
 

--- a/test/tracker.jl
+++ b/test/tracker.jl
@@ -40,6 +40,10 @@ end
 @test gradtest(x -> logsoftmax(x; dims = 1).*(1:3), (3,5))
 @test gradtest(x -> logsoftmax(x; dims = 2).*(1:3), (3,5))
 
+RNG = NNlib.Random.Xoshiro(1)
+@test gradtest(x -> dropout(copy(RNG), x, 0.5), 10)
+@test gradtest(x -> dropout(copy(RNG), x, 0.4; dims=1), (8, 9))
+
 @test gradtest(x -> x', rand(5))
 
 @test gradtest(det, (4, 4))


### PR DESCRIPTION
This upgrades `withgradient` to match the Zygote one:
```julia
julia> using Tracker

julia> withgradient(nt, 2) do x, p
         (; loss = sum(abs2, x.vec) ^ p, aux = x.vec)
       end
(val = (loss = 25.0, aux = [1.0, 2.0]), grad = ((vec = [20.0, 40.0], mat = [0.0;;], fun = nothing), nothing))
```
And it adds a rule for `NNlib.dropout`, which previously gave an error. 

(These are united only by trying to make Flux work with Tracker again.)