### PR TITLE
Fix Base.zero type output

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Tracker"
 uuid = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
-version = "0.2.34"
+version = "0.2.35"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/lib/array.jl
+++ b/src/lib/array.jl
@@ -144,7 +144,7 @@ logabsdet(xs::TrackedArray) = track(logabsdet, xs)
 @grad logabsdet(xs) = logabsdet(data(xs)), Δ -> (Δ[1] * transpose(inv(xs)),)
 
 Base.repeat(xs::TrackedArray; kw...) = track(repeat, xs; kw...)
-Base.zero(x::Tracker.TrackedArray) = zero.(x)
+Base.zero(x::Tracker.TrackedArray) = TrackedArray(zero(x.data))
 
 @grad function repeat(xs; inner=ntuple(x->1, ndims(xs)), outer=ntuple(x->1, ndims(xs)))
   repeat(data(xs), inner = inner, outer = outer), function (Δ)

--- a/test/tracker.jl
+++ b/test/tracker.jl
@@ -52,6 +52,11 @@ RNG = NNlib.Random.MersenneTwister(1)
 
 end # @testset gradtests
 
+@testset "zero" begin
+  @test zero(TrackedArray(rand(2))) isa TrackedArray
+  @test gradtest(x-> zero(x) .* x, (2,))
+end
+
 @testset "indexing & slicing" begin
   @test gradtest(x->view(x, 1:2, 1:2), rand(4, 4))
 end


### PR DESCRIPTION
zero(x::T)::T is a standard that applies to pretty much any other array type, but TrackedArray fails to match the standard interfaces. This fixes that issue. The only major violation to where this behavior is expected is if you're trying to write a grad rule that's mutating, which really only shows up in rules libraries, and those are thus updated here.

Note that there is an alternative implementation via `zero.(x)`, but this implementation drops the compute graph that isn't needed if you have a zero.
